### PR TITLE
Added Ravencoin prefixes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,11 +1,11 @@
 [settings]
-pubkeyprefix = 00
+pubkeyprefix = 3C
 privkeyprefix = 80
 compressed = yes
 
 #Change the pubkeyprefix and privkeyprefix setting above
-#to the values corresponding to the coin type the wallet.dat is for.
-#Below are short lists of a few coins, works for coins not listed if prefixes are known.
+#to the values corresponding to the coin type the wallet.dat is for. Current setting is for Ravencoin
+#Below are short lists of a few coins, works for coins not listed if hex prefixes are known.
 
 #pubkeyprefix list
 #Bitcoin: 00
@@ -14,6 +14,7 @@ compressed = yes
 #Litecoin: 30
 #Reddcoin: 3d
 #ZCash/ZClassic (only t addresses): 1cb8
+#Ravencoin: 3C
 
 #privkeyprefix list
 #Bitcoin: 80
@@ -22,3 +23,4 @@ compressed = yes
 #Litecoin: b0
 #Reddcoin: bd
 #ZCash/ZClassic (only t addresses): 80
+#Ravencoin: 80

--- a/config.ini
+++ b/config.ini
@@ -4,7 +4,7 @@ privkeyprefix = 80
 compressed = yes
 
 #Change the pubkeyprefix and privkeyprefix setting above
-#to the values corresponding to the coin type the wallet.dat is for. Current setting is for Ravencoin
+#to the values corresponding to the coin type the wallet.dat is for. Current setting is for Ravencoin.
 #Below are short lists of a few coins, works for coins not listed if hex prefixes are known.
 
 #pubkeyprefix list


### PR DESCRIPTION
Used the ravencoin prefix as standard in my repo as support for the Ravencoin community dealing with corrupted wallet.dat files.

Only merge the new ravencoin prefixes if desired.